### PR TITLE
User.objects is UserManager[Self]

### DIFF
--- a/django-stubs/contrib/auth/models.pyi
+++ b/django-stubs/contrib/auth/models.pyi
@@ -15,6 +15,11 @@ if sys.version_info < (3, 8):
 else:
     from typing import Literal
 
+if sys.version_info < (3, 11):
+    from typing_extensions import Self
+else:
+    from typing import Self
+
 _AnyUser = Union[Model, "AnonymousUser"]
 
 def update_last_login(
@@ -104,7 +109,7 @@ class AbstractUser(AbstractBaseUser, PermissionsMixin):
     ) -> None: ...
 
 class User(AbstractUser):
-    objects: UserManager[User]
+    objects: UserManager[Self]
 
 class AnonymousUser:
     id: Any = ...

--- a/tests/pyright/test_user.py
+++ b/tests/pyright/test_user.py
@@ -1,0 +1,24 @@
+from .base import Result, run_pyright
+
+def test_user_manager_specialises_to_self():
+    results = run_pyright(
+        """\
+from django.db import models
+from django.contrib.auth import models as auth_models
+
+class MyUser(auth_models.User):
+    age = models.IntegerField()
+
+u = MyUser()
+reveal_type(u.objects)
+"""
+        )
+
+    assert results == [
+        Result(
+            type="information",
+            message='Type of "u.objects" is "UserManager[MyUser]"',
+            line=8,
+            column=13,
+        ),
+    ]


### PR DESCRIPTION
This commit fixes the issue where you extend the User class. Previously, MySpecialUser.objects would return a UserManager[User]. This commit updates the objects field to paramterise over Self, so that MySpecialUser.objects returns a UserManager[MySpecialUser].